### PR TITLE
RepeatingPatterns: Fix examples

### DIFF
--- a/src/Hackspace/Bundle/CalciferBundle/Resources/views/RepeatingEvent/repeating_patterns.html.twig
+++ b/src/Hackspace/Bundle/CalciferBundle/Resources/views/RepeatingEvent/repeating_patterns.html.twig
@@ -26,8 +26,8 @@
             <p>Es gibt 2 verschiedene Wiederholungsmustertypen. Feste Termine oder Interval Termine.</p>
 
             <p>Der erste definiert sich dadurch das der Termin immer an einem bestimmten Tag im Monat passieren soll.
-                Das Hackspace-Plenum findet z.B. am „<code>Zweiten Freitag des Monats</code>“ statt. Die
-                Sicherheitssprechstunde findet immer am „<code>Ersten Dienstag des Monats</code>“ statt. Anhand dieser
+                Das Hackspace-Plenum findet z.B. am „<code>Zweiter Freitag des Monats</code>“ statt. Die
+                Sicherheitssprechstunde findet immer am „<code>Erster Dienstag des Monats</code>“ statt. Anhand dieser
                 Beispiele sollte eigentlich klar sein wie dieses Wiederholungsmuster funktioniert:</p>
 
             <p>An erster stelle definiert man die Woche: Erster, Zweiter, Dritter, Letzter (In manchen Fällen kann


### PR DESCRIPTION
Verwenden der vorherigen Beispiele führt zu Fehlern - Ersten/Zweiten wird nicht erkannt, nur Erster/Zweiter sind zulässig.