### PR TITLE
fixed deleting recurring appointments being broken

### DIFF
--- a/src/Hackspace/Bundle/CalciferBundle/Entity/RepeatingEventLogEntry.php
+++ b/src/Hackspace/Bundle/CalciferBundle/Entity/RepeatingEventLogEntry.php
@@ -35,7 +35,7 @@ class RepeatingEventLogEntry extends BaseEntity
      * @var RepeatingEvent
      *
      * @ORM\ManyToOne(targetEntity="RepeatingEvent")
-     * @ORM\JoinColumn(name="repeating_events_id", referencedColumnName="id")
+     * @ORM\JoinColumn(name="repeating_events_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $repeating_event;
 


### PR DESCRIPTION
Fix for #65 

Changed action for `ON DELETE` part of foreign key between relations `repeated_events` and `repeated_events_log_entries` to `CASCADE`, as this is probably what you want your DBMS to do when deleting recurring appointments.

The change introduced with this PR only applies when the Calcifer database is newly generated. To fix the problem for an already deployed database, use the following SQL statement and replace **<fk_name>** with the actual name of the problematic foreign key.
```
ALTER TABLE repeating_events_log_entries
    DROP CONSTRAINT <fk_name>,
    ADD CONSTRAINT <fk_name>
        FOREIGN KEY (repeating_events_id) REFERENCES repeating_events(id) ON DELETE CASCADE;
```